### PR TITLE
Add build-type selector with async build (prepare/poll + live logs)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,13 @@ import * as React from 'react';
 import { NavigateFunction, useNavigate } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import {
-  Client, GetQueryRunResponse, GetTagsResponse, RunQueryResponse,
+  Client,
+  GetBuildTypesResponse,
+  GetQueryRunResponse,
+  GetTagsResponse,
+  ImageStatusResponse,
+  RunQueryResponse,
+  RELEASE_BUILD_TYPE,
 } from './api/PlaygroundAPI';
 import Header from './components/Header';
 import EditorPanel from './components/EditorPanel';
@@ -20,14 +26,26 @@ const apiUrl = process.env.REACT_APP_API_URL;
 const githubRepoUrl = 'https://github.com/lodthe/clickhouse-playground';
 
 const localStorageFormatKey = 'clickhouse-playground-format';
+const localStorageBuildTypeKey = 'clickhouse-playground-build-type';
+
+// How often the image build status is polled while a non-release image is being built.
+const buildPollIntervalMs = 2000;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => {
+  window.setTimeout(resolve, ms);
+});
 
 type State = {
   tags: string[];
+  buildTypes: string[];
   selectedVersion: string;
+  selectedBuildType: string;
   selectedFormat: string;
   input: string;
   initialInput: string;
   requestIsRunning: boolean;
+  buildStatus: string;
+  buildElapsedSec: number;
   output: string;
   timeElapsed?: string;
 };
@@ -41,6 +59,11 @@ class App extends React.Component<AppProps, State> {
 
   navigate: NavigateFunction;
 
+  // Ticking timer that shows how long the current image build has been running.
+  buildTimer?: ReturnType<typeof setInterval>;
+
+  buildStartMs = 0;
+
   constructor(props: AppProps) {
     super(props);
     this.navigate = props.navigate;
@@ -48,11 +71,15 @@ class App extends React.Component<AppProps, State> {
 
     this.state = {
       tags: ['latest'],
+      buildTypes: [RELEASE_BUILD_TYPE],
       selectedVersion: 'latest',
+      selectedBuildType: localStorage.getItem(localStorageBuildTypeKey) || RELEASE_BUILD_TYPE,
       selectedFormat: localStorage.getItem(localStorageFormatKey) || 'TabSeparated',
       input: '',
       initialInput: '',
       requestIsRunning: false,
+      buildStatus: '',
+      buildElapsedSec: 0,
       output: '',
       timeElapsed: undefined,
     };
@@ -94,7 +121,46 @@ class App extends React.Component<AppProps, State> {
       .catch((error) => {
         console.log(error);
       });
+
+    this.client
+      .getBuildTypes()
+      .then((result: GetBuildTypesResponse) => {
+        const buildTypes = result.buildTypes && result.buildTypes.length > 0
+          ? result.buildTypes
+          : [RELEASE_BUILD_TYPE];
+
+        this.setState((prev) => ({
+          buildTypes,
+          // Reset to release if the persisted build type is no longer offered.
+          selectedBuildType: buildTypes.includes(prev.selectedBuildType)
+            ? prev.selectedBuildType
+            : RELEASE_BUILD_TYPE,
+        }));
+      })
+      .catch((error) => {
+        console.log(error);
+      });
   }
+
+  componentWillUnmount() {
+    this.stopBuildTimer();
+  }
+
+  private startBuildTimer = () => {
+    this.buildStartMs = Date.now();
+    this.stopBuildTimer();
+    this.setState({ buildElapsedSec: 0 });
+    this.buildTimer = setInterval(() => {
+      this.setState({ buildElapsedSec: Math.floor((Date.now() - this.buildStartMs) / 1000) });
+    }, 1000);
+  };
+
+  private stopBuildTimer = () => {
+    if (this.buildTimer !== undefined) {
+      clearInterval(this.buildTimer);
+      this.buildTimer = undefined;
+    }
+  };
 
   private handleInputChange = (value: string) => {
     this.setState({
@@ -105,6 +171,13 @@ class App extends React.Component<AppProps, State> {
   private handleSelectedVersionChange = (newValue: string) => {
     this.setState({
       selectedVersion: newValue,
+    });
+  };
+
+  private handleSelectedBuildTypeChange = (newValue: string) => {
+    localStorage.setItem(localStorageBuildTypeKey, newValue);
+    this.setState({
+      selectedBuildType: newValue,
     });
   };
 
@@ -135,6 +208,7 @@ class App extends React.Component<AppProps, State> {
           initialInput: result.input,
           output: result.output,
           selectedVersion: result.version,
+          selectedBuildType: result.buildType,
         });
       })
       .catch((error) => {
@@ -149,37 +223,104 @@ class App extends React.Component<AppProps, State> {
       }));
   };
 
-  private runQuery = () => {
+  // ensureImageReady prepares a non-release image and polls until it is built.
+  // It returns true once the image is ready, or false (after setting an error output)
+  // if the build failed.
+  /* eslint-disable no-await-in-loop */
+  private ensureImageReady = async (version: string, buildType: string): Promise<boolean> => {
+    const stageText = (detail?: string) => detail || `Building ${buildType} image for ${version}`;
+
+    // While building, the right panel mirrors the live build log; fall back to a hint.
+    const applyStatus = (status: ImageStatusResponse) => {
+      this.setState({
+        buildStatus: stageText(status.detail),
+        output: status.logs
+          || `Preparing the ${buildType} build for ${version}…\n`
+            + 'The first run builds the image from CI artifacts and can take several minutes.',
+      });
+    };
+
+    let status = await this.client.prepareImage(version, buildType);
+    applyStatus(status);
+
+    while (status.state === 'building') {
+      await sleep(buildPollIntervalMs);
+      status = await this.client.getImageStatus(version, buildType);
+      applyStatus(status);
+    }
+
+    if (status.state === 'failed') {
+      const header = `Failed to build the ${buildType} image for ${version}: ${status.error || 'unknown error'}`;
+      this.setState({
+        output: status.logs ? `${header}\n\n--- build log ---\n${status.logs}` : header,
+      });
+      return false;
+    }
+
+    return status.state === 'ready';
+  };
+  /* eslint-enable no-await-in-loop */
+
+  private runQuery = async () => {
+    const {
+      input, selectedFormat,
+    } = this.state;
+    const selectedVersion = this.state.selectedVersion.trim();
+    const selectedBuildType = this.state.selectedBuildType.trim();
+
     this.setState({
       requestIsRunning: true,
       output: '',
+      buildStatus: '',
       timeElapsed: undefined,
     });
 
-    const { input, selectedVersion, selectedFormat } = this.state;
-
-    this.client
-      .runQuery(input, selectedVersion, selectedFormat)
-      .then((result: RunQueryResponse) => {
+    try {
+      const isRelease = !selectedBuildType || selectedBuildType === RELEASE_BUILD_TYPE;
+      if (!isRelease) {
         this.setState({
-          output: result.output,
-          timeElapsed: result.timeElapsed,
+          output: `Preparing the ${selectedBuildType} build for ${selectedVersion}.\n`
+            + 'The first run builds the image from CI artifacts and can take several minutes…',
         });
 
-        const path = `/${result.queryRunId}`;
-        if (this.navigate != null) {
-          this.navigate(path);
+        this.startBuildTimer();
+        const ready = await this.ensureImageReady(selectedVersion, selectedBuildType);
+        if (!ready) {
+          return;
         }
-      })
-      .catch((error) => {
-        console.log(error);
-        this.setState({
-          output: error.message,
-        });
-      })
-      .finally(() => this.setState({
+
+        // Keep the timer running through container start + query execution.
+        this.setState({ buildStatus: 'Running query', output: '' });
+      }
+
+      const result: RunQueryResponse = await this.client.runQuery(
+        input,
+        selectedVersion,
+        selectedBuildType,
+        selectedFormat,
+      );
+
+      this.setState({
+        output: result.output,
+        timeElapsed: result.timeElapsed,
+      });
+
+      const path = `/${result.queryRunId}`;
+      if (this.navigate != null) {
+        this.navigate(path);
+      }
+    } catch (error) {
+      console.log(error);
+      this.setState({
+        output: (error as Error).message,
+      });
+    } finally {
+      this.stopBuildTimer();
+      this.setState({
         requestIsRunning: false,
-      }));
+        buildStatus: '',
+      });
+    }
   };
 
   private isFormatSelectionDisabled = (): boolean => {
@@ -216,13 +357,18 @@ class App extends React.Component<AppProps, State> {
       >
         <Header
           tags={this.state.tags}
+          buildTypes={this.state.buildTypes}
           selectedVersion={this.state.selectedVersion}
+          selectedBuildType={this.state.selectedBuildType}
           selectedFormat={this.state.selectedFormat}
           outputFormats={outputFormats}
           requestIsRunning={this.state.requestIsRunning}
+          buildStatus={this.state.buildStatus}
+          buildElapsedSec={this.state.buildElapsedSec}
           isFormatSelectionDisabled={formatDisabled}
           githubRepoUrl={githubRepoUrl}
           onVersionChange={this.handleSelectedVersionChange}
+          onBuildTypeChange={this.handleSelectedBuildTypeChange}
           onFormatChange={this.handleSelectedFormatChange}
           onRunClick={this.handleRunButtonClick}
         />
@@ -231,6 +377,7 @@ class App extends React.Component<AppProps, State> {
           output={this.state.output}
           timeElapsed={this.state.timeElapsed}
           requestIsRunning={this.state.requestIsRunning}
+          followOutput={this.state.requestIsRunning && this.state.buildStatus !== ''}
           onInputChange={this.handleInputChange}
         />
       </Box>

--- a/src/api/PlaygroundAPI.tsx
+++ b/src/api/PlaygroundAPI.tsx
@@ -2,8 +2,23 @@ export type GetTagsResponse = {
   tags: string[];
 };
 
+export type GetBuildTypesResponse = {
+  buildTypes: string[];
+};
+
+// ImageBuildState mirrors the backend qrunner.ImageState values.
+export type ImageBuildState = 'building' | 'ready' | 'failed';
+
+export type ImageStatusResponse = {
+  state: ImageBuildState;
+  detail?: string;
+  logs?: string;
+  error?: string;
+};
+
 export type GetQueryRunResponse = {
   version: string;
+  buildType: string;
   input: string;
   output: string;
   queryRunId: string;
@@ -14,6 +29,8 @@ export type RunQueryResponse = {
   output: string;
   timeElapsed: string;
 };
+
+export const RELEASE_BUILD_TYPE = 'release';
 
 export class Client {
   apiBaseUrl: string;
@@ -38,7 +55,81 @@ export class Client {
       });
   }
 
-  public runQuery(query: string, version: string, format: string): Promise<RunQueryResponse> {
+  public getBuildTypes(): Promise<GetBuildTypesResponse> {
+    return fetch(`${this.apiBaseUrl}build-types`)
+      .then((response) => response.json())
+      .then((response) => {
+        if (response.result) {
+          return {
+            buildTypes: response.result.build_types,
+          };
+        }
+        throw Error(response.error.message);
+      })
+      .catch((error) => {
+        throw error;
+      });
+  }
+
+  // prepareImage triggers (or re-triggers) a local build of a non-release image and
+  // returns the current build state.
+  public prepareImage(version: string, buildType: string): Promise<ImageStatusResponse> {
+    const requestMetadata = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        version,
+        build_type: buildType,
+      }),
+    };
+
+    return fetch(`${this.apiBaseUrl}images/prepare`, requestMetadata)
+      .then((response) => response.json())
+      .then((response) => {
+        if (response.result) {
+          return {
+            state: response.result.state,
+            detail: response.result.detail,
+            logs: response.result.logs,
+            error: response.result.error,
+          };
+        }
+        throw Error(response.error.message);
+      })
+      .catch((error) => {
+        throw error;
+      });
+  }
+
+  public getImageStatus(version: string, buildType: string): Promise<ImageStatusResponse> {
+    const params = new URLSearchParams({ version, build_type: buildType });
+
+    return fetch(`${this.apiBaseUrl}images/status?${params.toString()}`)
+      .then((response) => response.json())
+      .then((response) => {
+        if (response.result) {
+          return {
+            state: response.result.state,
+            detail: response.result.detail,
+            logs: response.result.logs,
+            error: response.result.error,
+          };
+        }
+        throw Error(response.error.message);
+      })
+      .catch((error) => {
+        throw error;
+      });
+  }
+
+  public runQuery(
+    query: string,
+    version: string,
+    buildType: string,
+    format: string,
+  ): Promise<RunQueryResponse> {
     const requestMetadata = {
       method: 'POST',
       headers: {
@@ -47,6 +138,7 @@ export class Client {
       body: JSON.stringify({
         query,
         version,
+        build_type: buildType,
         settings: {
           clickhouse: {
             output_format: format,
@@ -79,6 +171,7 @@ export class Client {
         if (response.result) {
           return {
             version: response.result.version,
+            buildType: response.result.build_type || RELEASE_BUILD_TYPE,
             input: response.result.input,
             output: response.result.output,
             queryRunId: response.result.query_run_id,

--- a/src/components/EditorPanel.tsx
+++ b/src/components/EditorPanel.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { useEffect } from 'react';
-import CodeMirror from '@uiw/react-codemirror';
+import { useEffect, useRef } from 'react';
+import CodeMirror, { ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { sql } from '@codemirror/lang-sql';
 import { EditorView } from '@codemirror/view';
 import { autocompletion } from '@codemirror/autocomplete';
@@ -19,6 +19,7 @@ interface EditorPanelProps {
   output: string;
   timeElapsed?: string;
   requestIsRunning: boolean;
+  followOutput: boolean;
   onInputChange: (value: string) => void;
 }
 
@@ -27,12 +28,25 @@ function EditorPanel({
   output,
   timeElapsed,
   requestIsRunning,
+  followOutput,
   onInputChange,
 }: EditorPanelProps) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   const panelDirection = isMobile ? 'vertical' : 'horizontal';
+
+  // While streaming build logs, keep the output scrolled to the latest line.
+  const outputRef = useRef<ReactCodeMirrorRef>(null);
+  useEffect(() => {
+    if (!followOutput) {
+      return;
+    }
+    const { view } = outputRef.current ?? {};
+    if (view) {
+      view.scrollDOM.scrollTop = view.scrollDOM.scrollHeight;
+    }
+  }, [output, followOutput]);
 
   useEffect(() => {
     const style = document.createElement('style');
@@ -166,6 +180,7 @@ function EditorPanel({
           }}
         >
           <CodeMirror
+            ref={outputRef}
             theme={xcodeLight}
             value={output}
             basicSetup={{

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,32 +4,52 @@ import Toolbar from '@mui/material/Toolbar';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
 import { PlayArrow } from '@mui/icons-material';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import SelectDropdown from './SelectDropdown';
 
+// formatElapsed renders a seconds count as m:ss (e.g. 83 -> "1:23").
+function formatElapsed(totalSeconds: number): string {
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
 interface HeaderProps {
   tags: string[];
+  buildTypes: string[];
   selectedVersion: string;
+  selectedBuildType: string;
   selectedFormat: string;
   outputFormats: string[];
   requestIsRunning: boolean;
+  buildStatus: string;
+  buildElapsedSec: number;
   isFormatSelectionDisabled: boolean;
   githubRepoUrl: string;
   onVersionChange: (newValue: string) => void;
+  onBuildTypeChange: (newValue: string) => void;
   onFormatChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onRunClick: (event: React.FormEvent) => void;
 }
 
 function Header({
   tags,
+  buildTypes,
   selectedVersion,
+  selectedBuildType,
   selectedFormat,
   outputFormats,
   requestIsRunning,
+  buildStatus,
+  buildElapsedSec,
   isFormatSelectionDisabled,
   githubRepoUrl,
   onVersionChange,
+  onBuildTypeChange,
   onFormatChange,
   onRunClick,
 }: HeaderProps) {
@@ -49,6 +69,24 @@ function Header({
               px: 1,
               flexGrow: 1,
               minWidth: '150px',
+            }}
+            disableDisplay={false}
+          />
+
+          <SelectDropdown
+            id="select-build-type"
+            options={buildTypes}
+            value={selectedBuildType}
+            onChange={onBuildTypeChange}
+            disabled={requestIsRunning || buildTypes.length <= 1}
+            label="Build"
+            sx={{
+              my: 1,
+              px: 1,
+              width: '160px',
+              minWidth: '160px',
+              flexGrow: 0,
+              flexShrink: 0,
             }}
             disableDisplay={false}
           />
@@ -86,6 +124,17 @@ function Header({
             <PlayArrow fontSize="large" />
             Run query
           </Button>
+
+          {buildStatus && (
+            <Chip
+              color="secondary"
+              variant="outlined"
+              icon={<CircularProgress size={16} color="inherit" />}
+              label={`${buildStatus} ${formatElapsed(buildElapsedSec)}`}
+              sx={{ my: 2, mx: 1, maxWidth: '100%' }}
+            />
+          )}
+
           <Box sx={{ flexGrow: 5 }} />
 
           <IconButton


### PR DESCRIPTION
## What

Adds a **Build** dropdown next to the version selector so users can run non-release ClickHouse builds — **debug / asan / tsan / msan / ubsan** — in addition to the default `release`.

Companion backend PR: lodthe/clickhouse-playground#57 (adds the `/api/build-types`, `/api/images/prepare`, `/api/images/status` endpoints and `build_type` on `/api/runs`).

## How it works

- For **release** (default), behaviour is unchanged.
- For a non-release build, **Run query**:
  1. calls `POST /api/images/prepare` and polls `GET /api/images/status` until the image is `ready`,
  2. streams the **live build log** into the output panel (right side) with **auto-scroll**, while the header chip shows the current **stage** (`Downloading packages`, `Installing packages`, …) and an **elapsed timer**,
  3. then runs the query (`build_type` is sent to `/api/runs`).
- On a failed build, the failure + build-log tail is shown in the output panel.

## Changes
- `api/PlaygroundAPI`: `getBuildTypes`, `prepareImage`, `getImageStatus`; `build_type` on `runQuery`/`getQueryRun`.
- `App`: prepare-then-run flow, build timer, stage/log state, trims the selected version.
- `Header`: build-type dropdown + stage/elapsed-timer chip.
- `EditorPanel`: streams build logs into the output panel and auto-scrolls to the latest line.

## Testing
`npm run lint` and `npm run build` pass (only pre-existing `no-console` warnings). Verified end-to-end against the backend PR via the local docker-compose stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
